### PR TITLE
Update Subs-SMF2WP-User.php

### DIFF
--- a/Subs-SMF2WP-User.php
+++ b/Subs-SMF2WP-User.php
@@ -66,7 +66,7 @@ function smf2wp_login($memberName, $hash_password, $cookieTime){
         */
 		wp_set_auth_cookie($user->ID);
 		wp_set_current_user($user->ID, $user->user_login);
-	} else if (!empty($_POST['passwrd'])) {
+	} else if (!empty($_POST['hash_passwrd'])) {
 		global $smcFunc;
 		$request = $smcFunc['db_query'](
 			'', 


### PR DESCRIPTION
After testing in my scenario, I figured that the SMF login form sends hash_passwrd instead of passwrd. After doing the proposed change, everything works fine.